### PR TITLE
Add doc generation to node artifacts

### DIFF
--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -4,6 +4,11 @@ if [ "${TRAVIS_NODE_VERSION}" != "${ARTIFACT_NODE_VERSION}" ]; then
     exit 0
 fi
 
+# If project has set BUILD_OPENAPI_DOC environment variable to true, then we build the openapi doc
+if [ ${BUILD_OPENAPI_DOC} = true ]; then
+    npm run build-doc
+fi
+
 if [ -n "${TRAVIS_TAG:-}" ]; then
     ARTIFACT_DIR='deploy'
 


### PR DESCRIPTION
Review node artifacts so openapi documentation can be generated if project is ready for it.

Doc generation is done all the time so we can face a doc generation problem each time the pipeline is running. Although I was not able to make the doc generation crash so it might not help too much in the end?

The doc is moved to 'doc/' folder to later be deployed by Travis to a S3 dedicated to doc.

If you guys are ok with that, we can probably have the same process for Go projects (need to modify artifact_go.sh I believe)

This PR is tied to [Gatekeeper](https://github.com/mdblp/gatekeeper/pull/8) making an example of this usage.