### PR TITLE
Add condition to microscanner security scan, disabled by default

### DIFF
--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -33,10 +33,13 @@ echo "Build Docker images"
 docker build --tag "${DOCKER_REPO}:development" --target=development .
 docker build --tag "${DOCKER_REPO}" .
 
-# Microscanner security scan on the built image
-wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
-chmod +x scanDockerImage.sh
-MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
+if [ ${SECURITY_SCAN:-false} = true ]; then
+    echo "Security scan"
+    # Microscanner security scan on the built image
+    wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
+    chmod +x scanDockerImage.sh
+    MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
+fi
 
 if [ "${TRAVIS_BRANCH:-}" == "dblp" -a "${TRAVIS_PULL_REQUEST_BRANCH:-}" == "" -o -n "${TRAVIS_TAG:-}" ]; then
     # Publish Docker images

--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -56,10 +56,13 @@ DOCKER_REPO="docker.ci.diabeloop.eu/${TRAVIS_REPO_SLUG#*/}"
 echo "Building docker image"
 docker build --tag "${DOCKER_REPO}" --build-arg npm_token=${nexus_token} .
 
-# Microscanner security scan on the built image
-wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
-chmod +x scanDockerImage.sh
-MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
+if [ ${SECURITY_SCAN:-false} = true ]; then
+    echo "Security scan"
+    # Microscanner security scan on the built image
+    wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
+    chmod +x scanDockerImage.sh
+    MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
+fi
 
 # Publish docker image only when we have a tag.
 # To avoid publishing 2x (on the branch build + PR) do not do it on the PR build.


### PR DESCRIPTION
Because today some services fail due to microscanner (e.g. Blip), we do not run it by default. It will be each service responsibility to specifically request scan in its pipeline