### PR TITLE
PT-1389 Add script to build soup list for GO modules

### DIFF
--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -eu
+#!/bin/bash -eux
 
 if [ "${TRAVIS_GO_VERSION}" != "${ARTIFACT_GO_VERSION}" ]; then
     exit 0
@@ -8,6 +8,13 @@ fi
 if [ ${BUILD_OPENAPI_DOC:-false} = true ]; then
     echo "Build documentation"
     ./buildDoc.sh
+fi
+
+# If project has set BUILD_SOUP environment variable to true, then we build the SOUPs list
+SOUP_SCRIPT=${SOUP_SCRIPT:-buildSoup.sh}
+if [ ${BUILD_SOUP:-false} = true -a -f ${SOUP_SCRIPT} ]; then
+    echo "Build SOUPs list"
+    ./${SOUP_SCRIPT}
 fi
 
 if [ -n "${TRAVIS_TAG:-}" ]; then


### PR DESCRIPTION
Add variable to trigger the execution of a build script that generates soup documentation
- BUILD_SOUP=true will trigger the build
- SOUP_SCRIPT is the name of the build script. The default value is `buildSoup.sh`