### PR TITLE
YLP-126 Implement docker push to Ops repository

### DIFF
--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -67,15 +67,22 @@ main() {
     # Push docker image only when we have a tag
     # To avoid publishing 2x (on the branch build + PR) we do not do it on the PR build
     if [ -n "${TRAVIS_TAG}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" ]; then
+        echo "Docker push"
         # This line below removes "dblp." from the TRAVIS_TAG
         image_version=${TRAVIS_TAG/dblp./}
-        echo "Push image to Diabeloop registry"
-        pushDocker "docker.ci.diabeloop.eu" ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${docker_repo} ${image_version}
 
-        # We push to Pictime except if the service does not want to and if we don't have a tag for release candidate
-        if [[ ${PUSH_DOCKER_PICTIME:-true} != false && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
-            echo "Push image to Pictime registry"
-            pushDocker "registry.coreye.fr/diabeloop/artifacts/diabeloop_docker" ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${docker_repo} ${image_version}
+        # We push to Default if the registry host is set
+        if [[ ${DOCKER_REGISTRY}:-""} != "" ]]; then
+            echo "Push image to Default registry (${DOCKER_REGISTRY})"
+            pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${docker_repo} ${image_version}
+        else
+            echo "Skipping docker push on Default registry"
+        fi
+
+        # We push to Pictime if the registry host is set and if we don't have a tag for release candidate
+        if [[ ${PCT_DOCKER_REGISTRY:-""} != "" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
+            echo "Push image to Pictime registry (${PCT_DOCKER_REGISTRY})"
+            pushDocker ${PCT_DOCKER_REGISTRY} ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${docker_repo} ${image_version}
         else
             echo "Skipping push on Pictime registry"
         fi

--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -1,67 +1,89 @@
 #!/bin/bash -eux
 
-if [ "${TRAVIS_GO_VERSION}" != "${ARTIFACT_GO_VERSION}" ]; then
-    exit 0
-fi
+pushDocker() {
+    # $1 = docker registry
+    # $2 = registry username
+    # $3 = registry password
+    # $4 = image repository
+    # $5 = image tag
+    IMAGE_NAME="$1/$4:$5"
+    echo "Tag image $4 to ${IMAGE_NAME}"
+    docker tag "$4" "${IMAGE_NAME}"
+    echo "Login, push and logout"
+    echo "$3" | docker login --username "$2" --password-stdin $1
+    docker push "${IMAGE_NAME}"
+    docker logout $1
+}
 
-# If project has set BUILD_OPENAPI_DOC environment variable to true, then we build the openapi doc
-OPENAPI_SCRIPT=${OPENAPI_SCRIPT:-buildDoc.sh}
-if [ ${BUILD_OPENAPI_DOC:-false} = true -a -f ${OPENAPI_SCRIPT} ]; then
-    echo "Build documentation"
-    ./${OPENAPI_SCRIPT}
-fi
-
-# If project has set BUILD_SOUP environment variable to true, then we build the SOUPs list
-SOUP_SCRIPT=${SOUP_SCRIPT:-buildSoup.sh}
-if [ ${BUILD_SOUP:-false} = true -a -f ${SOUP_SCRIPT} ]; then
-    echo "Build SOUPs list"
-    ./${SOUP_SCRIPT}
-fi
-
-if [ -n "${TRAVIS_TAG:-}" ]; then
-    ARTIFACT_DIR='deploy'
-
-    APP="${TRAVIS_REPO_SLUG#*/}"
-    APP_DIR="${ARTIFACT_DIR}/${APP}"
-    APP_TAG="${APP}-${TRAVIS_TAG}"
-
-    rm -rf "${ARTIFACT_DIR}/" || { echo 'ERROR: Unable to delete artifact directory'; exit 1; }
-    mkdir -p "${APP_DIR}/" || { echo 'ERROR: Unable to create app directory'; exit 1; }
-
-    ./build.sh || { echo 'ERROR: Unable to build project'; exit 1; }
-
-    mv dist "${APP_DIR}/${APP_TAG}" || { echo 'ERROR: Unable to move app artifact directory'; exit 1; }
-
-    tar -c -z -f "${APP_DIR}/${APP_TAG}.tar.gz" -C "${APP_DIR}" "${APP_TAG}" || { echo 'ERROR: Unable to create artifact'; exit 1; }
-fi
-
-# Build Docker images whatever
-DOCKER_REPO="docker.ci.diabeloop.eu/${TRAVIS_REPO_SLUG#*/}"
-echo "Build Docker images"
-docker build --tag "${DOCKER_REPO}:development" --target=development .
-docker build --tag "${DOCKER_REPO}" .
-
-if [ ${SECURITY_SCAN:-false} = true ]; then
-    echo "Security scan"
-    # Microscanner security scan on the built image
-    wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
-    chmod +x scanDockerImage.sh
-    MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
-fi
-
-if [ "${TRAVIS_BRANCH:-}" == "dblp" -a "${TRAVIS_PULL_REQUEST_BRANCH:-}" == "" -o -n "${TRAVIS_TAG:-}" ]; then
-    # Publish Docker images
-    DOCKER_TAG=${TRAVIS_TAG/dblp./}
-
-    echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin ${DOCKER_REPO}
-
-    if [ "${TRAVIS_BRANCH:-}" == "dblp" -a "${TRAVIS_PULL_REQUEST_BRANCH:-}" == "" ]; then
-        echo "Push images to ${DOCKER_REPO}"
-        docker push "${DOCKER_REPO}"
+main() {
+    if [ "${TRAVIS_GO_VERSION}" != "${ARTIFACT_GO_VERSION}" ]; then
+        exit 0
     fi
-    if [ -n "${DOCKER_TAG:-}" ]; then
-        echo "Tag and push image to ${DOCKER_REPO}"
-        docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${DOCKER_TAG}"
-        docker push "${DOCKER_REPO}:${DOCKER_TAG}"
+
+    # If project has set BUILD_OPENAPI_DOC environment variable to true, then we build the openapi doc
+    OPENAPI_SCRIPT=${OPENAPI_SCRIPT:-buildDoc.sh}
+    if [ ${BUILD_OPENAPI_DOC:-false} = true -a -f ${OPENAPI_SCRIPT} ]; then
+        echo "Build documentation"
+        ./${OPENAPI_SCRIPT}
     fi
-fi
+
+    # If project has set BUILD_SOUP environment variable to true, then we build the SOUPs list
+    SOUP_SCRIPT=${SOUP_SCRIPT:-buildSoup.sh}
+    if [ ${BUILD_SOUP:-false} = true -a -f ${SOUP_SCRIPT} ]; then
+        echo "Build SOUPs list"
+        ./${SOUP_SCRIPT}
+    fi
+
+    if [ -n "${TRAVIS_TAG:-}" ]; then
+        ARTIFACT_DIR='deploy'
+
+        APP="${TRAVIS_REPO_SLUG#*/}"
+        APP_DIR="${ARTIFACT_DIR}/${APP}"
+        APP_TAG="${APP}-${TRAVIS_TAG}"
+
+        rm -rf "${ARTIFACT_DIR}/" || { echo 'ERROR: Unable to delete artifact directory'; exit 1; }
+        mkdir -p "${APP_DIR}/" || { echo 'ERROR: Unable to create app directory'; exit 1; }
+
+        ./build.sh || { echo 'ERROR: Unable to build project'; exit 1; }
+
+        mv dist "${APP_DIR}/${APP_TAG}" || { echo 'ERROR: Unable to move app artifact directory'; exit 1; }
+
+        tar -c -z -f "${APP_DIR}/${APP_TAG}.tar.gz" -C "${APP_DIR}" "${APP_TAG}" || { echo 'ERROR: Unable to create artifact'; exit 1; }
+    fi
+
+    # Build Docker images whatever
+    DOCKER_REPO="${TRAVIS_REPO_SLUG#*/}"
+    echo "Build Docker image ${DOCKER_REPO}"
+    docker build --tag "${DOCKER_REPO}" .
+
+    if [ ${SECURITY_SCAN:-false} = true ]; then
+        echo "Security scan"
+        # Microscanner security scan on the built image
+        wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
+        chmod +x scanDockerImage.sh
+        MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
+    fi
+
+    # Push docker image only when we have a tag
+    # To avoid publishing 2x (on the branch build + PR) we do not do it on the PR build
+    if [ -n "${TRAVIS_TAG}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" ]; then
+        # This below removes "dblp." from the TRAVIS_TAG
+        DOCKER_TAG=${TRAVIS_TAG/dblp./}
+        echo "Push image to Diabeloop registry"
+        DOCKER_REGISTRY="docker.ci.diabeloop.eu"
+        pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${DOCKER_REPO} ${DOCKER_TAG}
+
+        # We push to Pictime except if the service does not want to and if we don't have a tag for release candidate
+        if [[ ${PUSH_DOCKER_PICTIME:-true} == "true" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
+            echo "Push image to Pictime registry"
+            DOCKER_REGISTRY="registry.coreye.fr/diabeloop/artifacts/diabeloop_docker"
+            pushDocker ${DOCKER_REGISTRY} ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${DOCKER_REPO} ${DOCKER_TAG}
+        else
+            echo "Skipping push on Pictime registry"
+        fi
+    else
+        echo "Not a tag or pull request, not pushing the docker image"
+    fi
+}
+
+main

--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -6,12 +6,12 @@ pushDocker() {
     # $3 = registry password
     # $4 = image repository
     # $5 = image version
-    local image_name="$1/$4"
+    local img_tag="$1/$4:$5"
     echo "Tag image"
-    docker tag "$4" "${image_name}:$5"
+    docker tag "$4" "${img_tag}"
     echo "Login, push and logout"
     echo "$3" | docker login --username "$2" --password-stdin $1
-    docker push "${image_name}"
+    docker push "${img_tag}"
     docker logout $1
 }
 

--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -5,13 +5,13 @@ pushDocker() {
     # $2 = registry username
     # $3 = registry password
     # $4 = image repository
-    # $5 = image tag
-    IMAGE_NAME="$1/$4:$5"
-    echo "Tag image $4 to ${IMAGE_NAME}"
-    docker tag "$4" "${IMAGE_NAME}"
+    # $5 = image version
+    local image_name="$1/$4"
+    echo "Tag image"
+    docker tag "$4" "${image_name}:$5"
     echo "Login, push and logout"
     echo "$3" | docker login --username "$2" --password-stdin $1
-    docker push "${IMAGE_NAME}"
+    docker push "${image_name}"
     docker logout $1
 }
 
@@ -51,33 +51,31 @@ main() {
         tar -c -z -f "${APP_DIR}/${APP_TAG}.tar.gz" -C "${APP_DIR}" "${APP_TAG}" || { echo 'ERROR: Unable to create artifact'; exit 1; }
     fi
 
-    # Build Docker images whatever
-    DOCKER_REPO="${TRAVIS_REPO_SLUG#*/}"
-    echo "Build Docker image ${DOCKER_REPO}"
-    docker build --tag "${DOCKER_REPO}" .
+    # Build Docker image whatever (failfast strategy)
+    docker_repo="${TRAVIS_REPO_SLUG#*/}"
+    echo "Build Docker image ${docker_repo}"
+    docker build --tag "${docker_repo}" .
 
     if [ ${SECURITY_SCAN:-false} = true ]; then
         echo "Security scan"
         # Microscanner security scan on the built image
         wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/dblp/artifact/scanDockerImage.sh'
         chmod +x scanDockerImage.sh
-        MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
+        MICROSCANNER_TOKEN=${MICROSCANNER_TOKEN} ./scanDockerImage.sh ${docker_repo}
     fi
 
     # Push docker image only when we have a tag
     # To avoid publishing 2x (on the branch build + PR) we do not do it on the PR build
     if [ -n "${TRAVIS_TAG}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" ]; then
-        # This below removes "dblp." from the TRAVIS_TAG
-        DOCKER_TAG=${TRAVIS_TAG/dblp./}
+        # This line below removes "dblp." from the TRAVIS_TAG
+        image_version=${TRAVIS_TAG/dblp./}
         echo "Push image to Diabeloop registry"
-        DOCKER_REGISTRY="docker.ci.diabeloop.eu"
-        pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${DOCKER_REPO} ${DOCKER_TAG}
+        pushDocker "docker.ci.diabeloop.eu" ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${docker_repo} ${image_version}
 
         # We push to Pictime except if the service does not want to and if we don't have a tag for release candidate
-        if [[ ${PUSH_DOCKER_PICTIME:-true} == "true" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
+        if [[ ${PUSH_DOCKER_PICTIME:-true} != false && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
             echo "Push image to Pictime registry"
-            DOCKER_REGISTRY="registry.coreye.fr/diabeloop/artifacts/diabeloop_docker"
-            pushDocker ${DOCKER_REGISTRY} ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${DOCKER_REPO} ${DOCKER_TAG}
+            pushDocker "registry.coreye.fr/diabeloop/artifacts/diabeloop_docker" ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${docker_repo} ${image_version}
         else
             echo "Skipping push on Pictime registry"
         fi

--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -59,7 +59,7 @@ main() {
     if [ ${SECURITY_SCAN:-false} = true ]; then
         echo "Security scan"
         # Microscanner security scan on the built image
-        wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
+        wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/dblp/artifact/scanDockerImage.sh'
         chmod +x scanDockerImage.sh
         MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
     fi

--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -65,29 +65,28 @@ main() {
     fi
 
     # Push docker image only when we have a tag
-    # To avoid publishing 2x (on the branch build + PR) we do not do it on the PR build
-    if [ -n "${TRAVIS_TAG}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" ]; then
+    if [ -n "${TRAVIS_TAG}" ]; then
         echo "Docker push"
         # This line below removes "dblp." from the TRAVIS_TAG
-        image_version=${TRAVIS_TAG/dblp./}
+        local image_version=${TRAVIS_TAG/dblp./}
 
         # We push to Default if the registry host is set
         if [[ ${DOCKER_REGISTRY}:-""} != "" ]]; then
             echo "Push image to Default registry (${DOCKER_REGISTRY})"
             pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${docker_repo} ${image_version}
         else
-            echo "Skipping docker push on Default registry"
+            echo "Skipping docker push to Default registry"
         fi
 
-        # We push to Pictime if the registry host is set and if we don't have a tag for release candidate
-        if [[ ${PCT_DOCKER_REGISTRY:-""} != "" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
-            echo "Push image to Pictime registry (${PCT_DOCKER_REGISTRY})"
-            pushDocker ${PCT_DOCKER_REGISTRY} ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${docker_repo} ${image_version}
+        # We push to Operations registry host is set and if we don't have a tag for release candidate
+        if [[ ${OPS_DOCKER_REGISTRY:-""} != "" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
+            echo "Push image to Operations registry (${OPS_DOCKER_REGISTRY})"
+            pushDocker ${OPS_DOCKER_REGISTRY} ${OPS_DOCKER_USERNAME} ${OPS_DOCKER_PASSWORD} ${docker_repo} ${image_version}
         else
-            echo "Skipping push on Pictime registry"
+            echo "Skipping push to Operations registry"
         fi
     else
-        echo "Not a tag or pull request, not pushing the docker image"
+        echo "Not a tag, not pushing the docker image"
     fi
 }
 

--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -1,81 +1,106 @@
 #!/bin/bash -eu
 
-# Print some variables, so we can debug this script if something goes wrong
-echo "ARTIFACT_NODE_VERSION: ${ARTIFACT_NODE_VERSION}"
-echo "TRAVIS_NODE_VERSION: ${TRAVIS_NODE_VERSION}"
-echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
-echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
-echo "TRAVIS_TAG: ${TRAVIS_TAG}"
-echo "TRAVIS_REPO_SLUG: ${TRAVIS_REPO_SLUG}"
+pushDocker() {
+    # $1 = docker registry
+    # $2 = registry username
+    # $3 = registry password
+    # $4 = image repository
+    # $5 = image tag
+    IMAGE_NAME="$1/$4:$5"
+    echo "Tag image $4 to ${IMAGE_NAME}"
+    docker tag "$4" "${IMAGE_NAME}"
+    echo "Login, push and logout"
+    echo "$3" | docker login --username "$2" --password-stdin $1
+    docker push "${IMAGE_NAME}"
+    docker logout $1
+}
 
-if [ "${TRAVIS_NODE_VERSION}" != "${ARTIFACT_NODE_VERSION}" ]; then
-    exit 0
-fi
+main() {
+    # Print some variables, so we can debug this script if something goes wrong
+    echo "ARTIFACT_NODE_VERSION: ${ARTIFACT_NODE_VERSION}"
+    echo "TRAVIS_NODE_VERSION: ${TRAVIS_NODE_VERSION}"
+    echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
+    echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
+    echo "TRAVIS_TAG: ${TRAVIS_TAG}"
+    echo "TRAVIS_REPO_SLUG: ${TRAVIS_REPO_SLUG}"
 
-# If project has set BUILD_OPENAPI_DOC environment variable to true, then we build the openapi doc
-if [ ${BUILD_OPENAPI_DOC:-false} = true ]; then
-    echo "Build documentation"
-    npm run build-doc
-fi
-
-# If project has set BUILD_SOUP environment variable to true, then we build the SOUPs list
-if [ ${BUILD_SOUP:-false} = true ]; then
-    echo "Build SOUPs list"
-    npm run build-soup
-fi
-
-if [ -n "${TRAVIS_TAG:-}" ]; then
-    ARTIFACT_DIR='deploy'
-
-    APP="${TRAVIS_REPO_SLUG#*/}"
-    APP_DIR="${ARTIFACT_DIR}/${APP}"
-    APP_TAG="${APP}-${TRAVIS_TAG}"
-
-    TMP_DIR="/tmp/${TRAVIS_REPO_SLUG}"
-
-    if [ -f '.artifactignore' ]; then
-        RSYNC_OPTIONS='--exclude-from=.artifactignore'
-    else
-        RSYNC_OPTIONS=''
+    if [ "${TRAVIS_NODE_VERSION}" != "${ARTIFACT_NODE_VERSION}" ]; then
+        exit 0
     fi
 
-    rm -rf "${ARTIFACT_DIR}/" "${TMP_DIR}/" || { echo 'ERROR: Unable to delete artifact and tmp directories'; exit 1; }
-    mkdir -p "${APP_DIR}/" "${TMP_DIR}/" || { echo 'ERROR: Unable to create app and tmp directories'; exit 1; }
+    # If project has set BUILD_OPENAPI_DOC environment variable to true, then we build the openapi doc
+    if [ ${BUILD_OPENAPI_DOC:-false} = true ]; then
+        echo "Build documentation"
+        npm run build-doc
+    fi
 
-    ./build.sh || { echo 'ERROR: Unable to build project'; exit 1; }
+    # If project has set BUILD_SOUP environment variable to true, then we build the SOUPs list
+    if [ ${BUILD_SOUP:-false} = true ]; then
+        echo "Build SOUPs list"
+        npm run build-soup
+    fi
 
-    rsync -a ${RSYNC_OPTIONS} . "${TMP_DIR}/${APP_TAG}/" || { echo 'ERROR: Unable to copy files'; exit 1; }
+    if [ -n "${TRAVIS_TAG:-}" ]; then
+        ARTIFACT_DIR='deploy'
 
-    tar -c -z -f "${APP_DIR}/${APP_TAG}.tar.gz" -C "${TMP_DIR}" "${APP_TAG}" || { echo 'ERROR: Unable to create artifact'; exit 1; }
+        APP="${TRAVIS_REPO_SLUG#*/}"
+        APP_DIR="${ARTIFACT_DIR}/${APP}"
+        APP_TAG="${APP}-${TRAVIS_TAG}"
 
-    rm -rf "${TMP_DIR}/"
-fi
+        TMP_DIR="/tmp/${TRAVIS_REPO_SLUG}"
 
-# Build Docker image whatever
-DOCKER_REPO="docker.ci.diabeloop.eu/${TRAVIS_REPO_SLUG#*/}"
-echo "Building docker image"
-docker build --tag "${DOCKER_REPO}" --build-arg npm_token=${nexus_token} .
+        if [ -f '.artifactignore' ]; then
+            RSYNC_OPTIONS='--exclude-from=.artifactignore'
+        else
+            RSYNC_OPTIONS=''
+        fi
 
-if [ ${SECURITY_SCAN:-false} = true ]; then
-    echo "Security scan"
-    # Microscanner security scan on the built image
-    wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
-    chmod +x scanDockerImage.sh
-    MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
-fi
+        rm -rf "${ARTIFACT_DIR}/" "${TMP_DIR}/" || { echo 'ERROR: Unable to delete artifact and tmp directories'; exit 1; }
+        mkdir -p "${APP_DIR}/" "${TMP_DIR}/" || { echo 'ERROR: Unable to create app and tmp directories'; exit 1; }
 
-# Publish docker image only when we have a tag.
-# To avoid publishing 2x (on the branch build + PR) do not do it on the PR build.
-if [ -n "${TRAVIS_TAG}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" ]; then
-    # Publish Docker image
-    DOCKER_TAG=${TRAVIS_TAG/dblp./}
+        ./build.sh || { echo 'ERROR: Unable to build project'; exit 1; }
 
-    echo "Docker login"
-    echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin ${DOCKER_REPO}
+        rsync -a ${RSYNC_OPTIONS} . "${TMP_DIR}/${APP_TAG}/" || { echo 'ERROR: Unable to copy files'; exit 1; }
 
-    echo "Tag and push image to ${DOCKER_REPO}:${DOCKER_TAG}"
-    docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${DOCKER_TAG}"
-    docker push "${DOCKER_REPO}:${DOCKER_TAG}"
-else
-    echo "Not a tag or pull request, not pushing the docker image"
-fi
+        tar -c -z -f "${APP_DIR}/${APP_TAG}.tar.gz" -C "${TMP_DIR}" "${APP_TAG}" || { echo 'ERROR: Unable to create artifact'; exit 1; }
+
+        rm -rf "${TMP_DIR}/"
+    fi
+
+    # Build Docker image whatever
+    DOCKER_REPO="${TRAVIS_REPO_SLUG#*/}"
+
+    echo "Build docker image ${DOCKER_REPO}"
+    docker build --tag "${DOCKER_REPO}" --build-arg npm_token=${nexus_token} .
+
+    if [ ${SECURITY_SCAN:-false} = true ]; then
+        echo "Security scan"
+        # Microscanner security scan on the built image
+        wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
+        chmod +x scanDockerImage.sh
+        MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
+    fi
+
+    # Push docker image only when we have a tag
+    # To avoid publishing 2x (on the branch build + PR) we do not do it on the PR build
+    if [ -n "${TRAVIS_TAG}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" ]; then
+        # This below removes "dblp." from the TRAVIS_TAG
+        DOCKER_TAG=${TRAVIS_TAG/dblp./}
+        echo "Push image to Diabeloop registry"
+        DOCKER_REGISTRY="docker.ci.diabeloop.eu"
+        pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${DOCKER_REPO} ${DOCKER_TAG}
+
+        # We push to Pictime except if the service does not want to and if we don't have a tag for release candidate
+        if [[ ${PUSH_DOCKER_PICTIME:-true} == "true" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
+            echo "Push image to Pictime registry"
+            DOCKER_REGISTRY="registry.coreye.fr/diabeloop/artifacts/diabeloop_docker"
+            pushDocker ${DOCKER_REGISTRY} ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${DOCKER_REPO} ${DOCKER_TAG}
+        else
+            echo "Skipping push on Pictime registry"
+        fi
+    else
+        echo "Not a tag or pull request, not pushing the docker image"
+    fi
+}
+
+main

--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -76,7 +76,7 @@ main() {
     if [ ${SECURITY_SCAN:-false} = true ]; then
         echo "Security scan"
         # Microscanner security scan on the built image
-        wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
+        wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/dblp/artifact/scanDockerImage.sh'
         chmod +x scanDockerImage.sh
         MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
     fi

--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -6,12 +6,12 @@ pushDocker() {
     # $3 = registry password
     # $4 = image repository
     # $5 = image version
-    local image_name="$1/$4"
+    local img_tag="$1/$4:$5"
     echo "Tag image"
-    docker tag "$4" "${image_name}:$5"
+    docker tag "$4" "${img_tag}"
     echo "Login, push and logout"
     echo "$3" | docker login --username "$2" --password-stdin $1
-    docker push "${image_name}"
+    docker push "${img_tag}"
     docker logout $1
 }
 

--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -82,29 +82,28 @@ main() {
     fi
 
     # Push docker image only when we have a tag
-    # To avoid publishing 2x (on the branch build + PR) we do not do it on the PR build
-    if [ -n "${TRAVIS_TAG}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" ]; then
+    if [ -n "${TRAVIS_TAG}" ]; then
         echo "Docker push"
         # This line below removes "dblp." from the TRAVIS_TAG
-        image_version=${TRAVIS_TAG/dblp./}
+        local image_version=${TRAVIS_TAG/dblp./}
 
         # We push to Default if the registry host is set
         if [[ ${DOCKER_REGISTRY}:-""} != "" ]]; then
             echo "Push image to Default registry (${DOCKER_REGISTRY})"
             pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${docker_repo} ${image_version}
         else
-            echo "Skipping docker push on Default registry"
+            echo "Skipping docker push to Default registry"
         fi
 
-        # We push to Pictime if the registry host is set and if we don't have a tag for release candidate
-        if [[ ${PCT_DOCKER_REGISTRY:-""} != "" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
-            echo "Push image to Pictime registry (${PCT_DOCKER_REGISTRY})"
-            pushDocker ${PCT_DOCKER_REGISTRY} ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${docker_repo} ${image_version}
+        # We push to Operations if the registry host is set and if we don't have a tag for release candidate
+        if [[ ${OPS_DOCKER_REGISTRY:-""} != "" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
+            echo "Push image to Operations registry (${OPS_DOCKER_REGISTRY})"
+            pushDocker ${OPS_DOCKER_REGISTRY} ${OPS_DOCKER_USERNAME} ${OPS_DOCKER_PASSWORD} ${docker_repo} ${image_version}
         else
-            echo "Skipping push on Pictime registry"
+            echo "Skipping push to Operations registry"
         fi
     else
-        echo "Not a tag or pull request, not pushing the docker image"
+        echo "Not a tag, not pushing the docker image"
     fi
 }
 

--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -84,15 +84,22 @@ main() {
     # Push docker image only when we have a tag
     # To avoid publishing 2x (on the branch build + PR) we do not do it on the PR build
     if [ -n "${TRAVIS_TAG}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" ]; then
+        echo "Docker push"
         # This line below removes "dblp." from the TRAVIS_TAG
         image_version=${TRAVIS_TAG/dblp./}
-        echo "Push image to Diabeloop registry"
-        pushDocker "docker.ci.diabeloop.eu" ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${docker_repo} ${image_version}
 
-        # We push to Pictime except if the service does not want to and if we don't have a tag for release candidate
-        if [[ ${PUSH_DOCKER_PICTIME:-true} != false && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
-            echo "Push image to Pictime registry"
-            pushDocker "registry.coreye.fr/diabeloop/artifacts/diabeloop_docker" ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${docker_repo} ${image_version}
+        # We push to Default if the registry host is set
+        if [[ ${DOCKER_REGISTRY}:-""} != "" ]]; then
+            echo "Push image to Default registry (${DOCKER_REGISTRY})"
+            pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${docker_repo} ${image_version}
+        else
+            echo "Skipping docker push on Default registry"
+        fi
+
+        # We push to Pictime if the registry host is set and if we don't have a tag for release candidate
+        if [[ ${PCT_DOCKER_REGISTRY:-""} != "" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
+            echo "Push image to Pictime registry (${PCT_DOCKER_REGISTRY})"
+            pushDocker ${PCT_DOCKER_REGISTRY} ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${docker_repo} ${image_version}
         else
             echo "Skipping push on Pictime registry"
         fi

--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -5,13 +5,13 @@ pushDocker() {
     # $2 = registry username
     # $3 = registry password
     # $4 = image repository
-    # $5 = image tag
-    IMAGE_NAME="$1/$4:$5"
-    echo "Tag image $4 to ${IMAGE_NAME}"
-    docker tag "$4" "${IMAGE_NAME}"
+    # $5 = image version
+    local image_name="$1/$4"
+    echo "Tag image"
+    docker tag "$4" "${image_name}:$5"
     echo "Login, push and logout"
     echo "$3" | docker login --username "$2" --password-stdin $1
-    docker push "${IMAGE_NAME}"
+    docker push "${image_name}"
     docker logout $1
 }
 
@@ -67,34 +67,32 @@ main() {
         rm -rf "${TMP_DIR}/"
     fi
 
-    # Build Docker image whatever
-    DOCKER_REPO="${TRAVIS_REPO_SLUG#*/}"
+    # Build Docker image whatever (failfast strategy)
+    docker_repo="${TRAVIS_REPO_SLUG#*/}"
 
-    echo "Build docker image ${DOCKER_REPO}"
-    docker build --tag "${DOCKER_REPO}" --build-arg npm_token=${nexus_token} .
+    echo "Build docker image ${docker_repo}"
+    docker build --tag "${docker_repo}" --build-arg npm_token=${nexus_token} .
 
     if [ ${SECURITY_SCAN:-false} = true ]; then
         echo "Security scan"
         # Microscanner security scan on the built image
         wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/dblp/artifact/scanDockerImage.sh'
         chmod +x scanDockerImage.sh
-        MICROSCANNER_TOKEN=${microscanner_token} ./scanDockerImage.sh ${DOCKER_REPO}
+        MICROSCANNER_TOKEN=${MICROSCANNER_TOKEN} ./scanDockerImage.sh ${docker_repo}
     fi
 
     # Push docker image only when we have a tag
     # To avoid publishing 2x (on the branch build + PR) we do not do it on the PR build
     if [ -n "${TRAVIS_TAG}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" ]; then
-        # This below removes "dblp." from the TRAVIS_TAG
-        DOCKER_TAG=${TRAVIS_TAG/dblp./}
+        # This line below removes "dblp." from the TRAVIS_TAG
+        image_version=${TRAVIS_TAG/dblp./}
         echo "Push image to Diabeloop registry"
-        DOCKER_REGISTRY="docker.ci.diabeloop.eu"
-        pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${DOCKER_REPO} ${DOCKER_TAG}
+        pushDocker "docker.ci.diabeloop.eu" ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${docker_repo} ${image_version}
 
         # We push to Pictime except if the service does not want to and if we don't have a tag for release candidate
-        if [[ ${PUSH_DOCKER_PICTIME:-true} == "true" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
+        if [[ ${PUSH_DOCKER_PICTIME:-true} != false && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
             echo "Push image to Pictime registry"
-            DOCKER_REGISTRY="registry.coreye.fr/diabeloop/artifacts/diabeloop_docker"
-            pushDocker ${DOCKER_REGISTRY} ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${DOCKER_REPO} ${DOCKER_TAG}
+            pushDocker "registry.coreye.fr/diabeloop/artifacts/diabeloop_docker" ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${docker_repo} ${image_version}
         else
             echo "Skipping push on Pictime registry"
         fi

--- a/artifact/artifact_packaging.sh
+++ b/artifact/artifact_packaging.sh
@@ -159,25 +159,25 @@ function publishDockerImage {
     if [ -n "${TRAVIS_TAG:-}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" -a -n "${DOCKER_USERNAME:-}" -a -n "${DOCKER_PASSWORD:-}" ]; then
         echo "Docker push"
         # This line below removes "dblp." from the TRAVIS_TAG
-        image_version=${TRAVIS_TAG/dblp./}
+        local image_version=${TRAVIS_TAG/dblp./}
 
         # We push to Default if the registry host is set
         if [[ ${DOCKER_REGISTRY}:-""} != "" ]]; then
             echo "Push image to Default registry (${DOCKER_REGISTRY})"
             pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${DOCKER_REPO} ${image_version}
         else
-            echo "Skipping docker push on Default registry"
+            echo "Skipping docker push to Default registry"
         fi
 
-        # We push to Pictime if the registry host is set and if we don't have a tag for release candidate
-        if [[ ${PCT_DOCKER_REGISTRY:-""} != "" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
-            echo "Push image to Pictime registry (${PCT_DOCKER_REGISTRY})"
-            pushDocker ${PCT_DOCKER_REGISTRY} ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${DOCKER_REPO} ${image_version}
+        # We push to Operations if the registry host is set and if we don't have a tag for release candidate
+        if [[ ${OPS_DOCKER_REGISTRY:-""} != "" && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
+            echo "Push image to Operations registry (${OPS_DOCKER_REGISTRY})"
+            pushDocker ${OPS_DOCKER_REGISTRY} ${OPS_DOCKER_USERNAME} ${OPS_DOCKER_PASSWORD} ${DOCKER_REPO} ${image_version}
         else
-            echo "Skipping push on Pictime registry"
+            echo "Skipping push to Operations registry"
         fi
     else
-        echo "Not a tag or pull request, not pushing the docker image"
+        echo "Not a tag, not pushing the docker image"
     fi
 }
 

--- a/artifact/artifact_packaging.sh
+++ b/artifact/artifact_packaging.sh
@@ -13,7 +13,7 @@ echo "NO_DEFAULT_PACKAGING: ${NO_DEFAULT_PACKAGING:-false}"
 
 REPO_SLUG="${TRAVIS_REPO_SLUG:-mdblp}"
 APP="${REPO_SLUG#*/}"
-DOCKER_REPO="docker.ci.diabeloop.eu/${APP}"
+DOCKER_REPO="${APP}"
 
 # If project has set BUILD_OPENAPI_DOC environment variable to true, then we build the openapi doc
 function buildDocumentation {
@@ -123,8 +123,8 @@ function buildDockerImage {
         esac
     done
 
-    echo "Building docker image ${DOCKER_REPO}${DOCKER_TAG} using ${DOCKER_FILE} from ${DOCKER_TARGET_DIR}"
-    docker build --tag "${DOCKER_REPO}${DOCKER_TAG}" --build-arg npm_token="${nexus_token}" -f "${DOCKER_FILE}" "${DOCKER_TARGET_DIR}"
+    echo "Building docker image ${DOCKER_REPO} using ${DOCKER_FILE} from ${DOCKER_TARGET_DIR}"
+    docker build --tag "${DOCKER_REPO}" --build-arg npm_token="${nexus_token}" -f "${DOCKER_FILE}" "${DOCKER_TARGET_DIR}"
 
     if [ "${SECURITY_SCAN:-false}" = "true" ]; then
         echo "Security scan of ${DOCKER_REPO}${DOCKER_SCAN_TAG}"
@@ -134,23 +134,41 @@ function buildDockerImage {
             docker build --target "${DOCKER_SCAN_TAG#*:}" --tag "${DOCKER_REPO}${DOCKER_SCAN_TAG}" --build-arg npm_token="${nexus_token}" -f "${DOCKER_FILE}" "${DOCKER_TARGET_DIR}"
         fi
         wget -q -O scanDockerImage.sh 'https://raw.githubusercontent.com/mdblp/tools/feature/add_microscanner/artifact/scanDockerImage.sh'
-        MICROSCANNER_TOKEN="${microscanner_token}" bash ./scanDockerImage.sh "${DOCKER_REPO}${DOCKER_SCAN_TAG}"
+        MICROSCANNER_TOKEN="${MICROSCANNER_TOKEN}" bash ./scanDockerImage.sh "${DOCKER_REPO}${DOCKER_SCAN_TAG}"
     fi
+}
+
+pushDocker() {
+    # $1 = docker registry
+    # $2 = registry username
+    # $3 = registry password
+    # $4 = image repository
+    # $5 = image version
+    local img_tag="$1/$4:$5"
+    echo "Tag image"
+    docker tag "$4" "${img_tag}"
+    echo "Login, push and logout"
+    echo "$3" | docker login --username "$2" --password-stdin $1
+    docker push "${img_tag}"
+    docker logout $1
 }
 
 # Publish docker image only when we have a tag.
 # To avoid publishing 2x (on the branch build + PR) do not do it on the PR build.
 function publishDockerImage {
     if [ -n "${TRAVIS_TAG:-}" -a "${TRAVIS_PULL_REQUEST:-false}" == "false" -a -n "${DOCKER_USERNAME:-}" -a -n "${DOCKER_PASSWORD:-}" ]; then
-        # Publish Docker image
-        DOCKER_TAG=${TRAVIS_TAG/dblp./}
+        # This line below removes "dblp." from the TRAVIS_TAG
+        image_version=${TRAVIS_TAG/dblp./}
+        echo "Push image to Diabeloop registry"
+        pushDocker "docker.ci.diabeloop.eu" ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${DOCKER_REPO} ${image_version}
 
-        echo "Docker login"
-        echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin ${DOCKER_REPO}
-
-        echo "Tag and push image to ${DOCKER_REPO}:${DOCKER_TAG}"
-        docker tag "${DOCKER_REPO}" "${DOCKER_REPO}:${DOCKER_TAG}"
-        docker push "${DOCKER_REPO}:${DOCKER_TAG}"
+        # We push to Pictime except if the service does not want to and if we don't have a tag for release candidate
+        if [[ ${PUSH_DOCKER_PICTIME:-true} != false && ! ${TRAVIS_TAG} =~ rc[0-9] ]]; then
+            echo "Push image to Pictime registry"
+            pushDocker "registry.coreye.fr/diabeloop/artifacts/diabeloop_docker" ${PCT_DOCKER_USERNAME} ${PCT_DOCKER_PASSWORD} ${DOCKER_REPO} ${image_version}
+        else
+            echo "Skipping push on Pictime registry"
+        fi        
     else
         echo "Not a tag or pull request, not pushing the docker image"
     fi


### PR DESCRIPTION
To push Docker image to Pictime, one needs to set environment variable PCT_DOCKER_REGISTRY (in Travis settings or .travis.yml)

### 1. Node
For **Node**, tests were done with gatekeeper (https://github.com/mdblp/gatekeeper/tree/test/test_artifact_docker):

### 2. Go
For **Go**, tests were done with hydrophone (https://github.com/mdblp/hydrophone/tree/test/test_new_artifact):

### 3. Blip (artifact_packaging.sh)
Blip is using artifact_packaging.sh

**Note:**

For Jenkins pipelines (YLP-127), refer to https://bitbucket.org/diabeloop/jenkins-pipeline-library/pull-requests/10
For Platform pipeline (YLP-131), refer to https://github.com/mdblp/platform/pull/67