### PR TITLE
Use GH Token so Trivy can request GH apis with no limit

### DIFF
--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -60,8 +60,8 @@ main() {
     if [ ${SECURITY_SCAN:-true} = true ]; then
         echo "Security scan using Trivy container"
         local trivy_version=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ aquasec/trivy:${trivy_version} image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${docker_repo}
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ aquasec/trivy:${trivy_version} image --exit-code 1 --severity CRITICAL,HIGH ${docker_repo}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${docker_repo}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 1 --severity CRITICAL,HIGH ${docker_repo}
     fi
 
     # Push docker image only when we have a tag

--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -77,8 +77,8 @@ main() {
     if [ ${SECURITY_SCAN:-true} = true ]; then
         echo "Security scan using Trivy container"
         local trivy_version=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ aquasec/trivy:${trivy_version} image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${docker_repo}
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ aquasec/trivy:${trivy_version} image --exit-code 1 --severity CRITICAL,HIGH ${docker_repo}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${docker_repo}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 1 --severity CRITICAL,HIGH ${docker_repo}
     fi
 
     # Push docker image only when we have a tag

--- a/artifact/artifact_packaging.sh
+++ b/artifact/artifact_packaging.sh
@@ -134,8 +134,8 @@ function buildDockerImage {
             docker build --target "${DOCKER_SCAN_TAG#*:}" --tag "${DOCKER_REPO}${DOCKER_SCAN_TAG}" --build-arg npm_token="${NEXUS_TOKEN}" -f "${DOCKER_FILE}" "${DOCKER_TARGET_DIR}"
         fi
         local trivy_version=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ aquasec/trivy:${trivy_version} image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${DOCKER_REPO}${DOCKER_SCAN_TAG}
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ aquasec/trivy:${trivy_version} image --exit-code 1 --severity CRITICAL,HIGH ${DOCKER_REPO}${DOCKER_SCAN_TAG}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${DOCKER_REPO}${DOCKER_SCAN_TAG}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 1 --severity CRITICAL,HIGH ${DOCKER_REPO}${DOCKER_SCAN_TAG}
     fi
 }
 


### PR DESCRIPTION
Tests were done on Gatekeeper/test/trivy_fix
By removing the GITHUB_TOKEN or changing it to a fake value in Travis settings, the job is failing, showing the token is correctly passed to trivy as an environment variabel