### PR TITLE
Use latest trivy image  

### DIFF
--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -59,9 +59,8 @@ main() {
     # Security scan on the built image
     if [ ${SECURITY_SCAN:-true} = true ]; then
         echo "Security scan using Trivy container"
-        local trivy_version=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${docker_repo}
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 1 --severity CRITICAL,HIGH ${docker_repo}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${docker_repo}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy image --exit-code 1 --severity CRITICAL,HIGH ${docker_repo}
     fi
 
     # Push docker image only when we have a tag

--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -76,9 +76,8 @@ main() {
     # Security scan on the built image
     if [ ${SECURITY_SCAN:-true} = true ]; then
         echo "Security scan using Trivy container"
-        local trivy_version=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${docker_repo}
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 1 --severity CRITICAL,HIGH ${docker_repo}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${docker_repo}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy image --exit-code 1 --severity CRITICAL,HIGH ${docker_repo}
     fi
 
     # Push docker image only when we have a tag

--- a/artifact/artifact_packaging.sh
+++ b/artifact/artifact_packaging.sh
@@ -133,9 +133,8 @@ function buildDockerImage {
             echo "Using a different tag for security scan"
             docker build --target "${DOCKER_SCAN_TAG#*:}" --tag "${DOCKER_REPO}${DOCKER_SCAN_TAG}" --build-arg npm_token="${NEXUS_TOKEN}" -f "${DOCKER_FILE}" "${DOCKER_TARGET_DIR}"
         fi
-        local trivy_version=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${DOCKER_REPO}${DOCKER_SCAN_TAG}
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy:${trivy_version} image --exit-code 1 --severity CRITICAL,HIGH ${DOCKER_REPO}${DOCKER_SCAN_TAG}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${DOCKER_REPO}${DOCKER_SCAN_TAG}
+        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy image --exit-code 1 --severity CRITICAL,HIGH ${DOCKER_REPO}${DOCKER_SCAN_TAG}
     fi
 }
 


### PR DESCRIPTION
As we experienced several failures [blip with logs](https://travis-ci.org/github/mdblp/blip/jobs/729900351) & [blip](https://travis-ci.org/github/mdblp/blip/jobs/729631855) when we try to get the latest version of trivy from github, we move to a simpler solution where we take the latest trivy image and we do not specify the version.
We are basically removing the below call that we are suspecting to fail from time to time: 
```
curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/'
```
The change will impact all jobs but do not require any changes.