### PR TITLE
YLP-194 Feature/review security scan

### DIFF
--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -25,13 +25,14 @@ triggerSecurityScan() {
         -F ref=master \
         -F "variables[IMAGE_NAME]=$1" \
         -F "variables[IMAGE_TAG]=$2" \
-        -F "variables[COMMIT_ID]=${TRAVIS_COMMIT}" \
+        -F "variables[COMMIT_ID]=${TRAVIS_PULL_REQUEST_SHA}" \
         -F "variables[REPO_SLUG]=${TRAVIS_REPO_SLUG}" \
-        https://git.coreye.fr/api/v4/projects/1433/trigger/pipeline
+        -F "variables[REMOVE_IMAGE]=true" \
+        https://git.coreye.fr/api/v4/projects/1433/trigger/pipeline
     # Attach new status "pending" to the commit for aquascanner context
     # Our Ops partner will update the status once the scanner is finished
-    echo "Set 'pending' status to commit ${TRAVIS_COMMIT}"
-    curl --location --request POST "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_COMMIT}" \
+    echo "Set 'pending' status to commit ${TRAVIS_PULL_REQUEST_SHA}"
+    curl --location --request POST "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_PULL_REQUEST_SHA}" \
         --header "Authorization: Bearer ${GITHUB_TOKEN}" \
         --header 'Content-Type: application/json' \
         --data-raw '{
@@ -42,6 +43,15 @@ triggerSecurityScan() {
 }
 
 main() {
+    # Print some variables, so we can debug this script if something goes wrong
+    echo "ARTIFACT_NODE_VERSION: ${ARTIFACT_NODE_VERSION}"
+    echo "TRAVIS_NODE_VERSION: ${TRAVIS_NODE_VERSION}"
+    echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
+    echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST}"
+    echo "TRAVIS_TAG: ${TRAVIS_TAG}"
+    echo "TRAVIS_REPO_SLUG: ${TRAVIS_REPO_SLUG}"
+    echo "TRAVIS_PULL_REQUEST_SHA: ${TRAVIS_PULL_REQUEST_SHA}"
+
     if [ "${TRAVIS_GO_VERSION}" != "${ARTIFACT_GO_VERSION}" ]; then
         exit 0
     fi
@@ -83,17 +93,21 @@ main() {
     docker build --tag "${docker_repo}" .
 
     # Security scan on the Operations registry
+    # The security scan is executed only for a PR build
     # The image has to be pushed to Operations registry to benefit from their security scanner
-    if [ ${SECURITY_SCAN:-true} = true ]; then
+    if [ ${SECURITY_SCAN:-true} = true ] && [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
         echo "Security scan"
-        if [[ ${OPS_DOCKER_REGISTRY:-""} != "" ]]; then
+        local scanTag="${TRAVIS_PULL_REQUEST_SHA}-scanOnly"
+        if [ ${OPS_DOCKER_REGISTRY:-""} != "" ]; then
             echo "Push image to Operations registry (${OPS_DOCKER_REGISTRY})"
-            pushDocker ${OPS_DOCKER_REGISTRY} ${OPS_DOCKER_USERNAME} ${OPS_DOCKER_PASSWORD} ${docker_repo} "scanOnly"
-            triggerSecurityScan ${docker_repo} "scanOnly"
+            pushDocker ${OPS_DOCKER_REGISTRY} ${OPS_DOCKER_USERNAME} ${OPS_DOCKER_PASSWORD} ${docker_repo} ${scanTag}
+            triggerSecurityScan ${docker_repo} ${scanTag}
         else
             echo "OPS Docker Registry unknown. Security Scan cannot occur."
             exit 1
         fi
+    else
+        echo "Skipping Security Scan"
     fi
 
     # Push docker image only when we have a tag
@@ -103,7 +117,7 @@ main() {
         local image_version=${TRAVIS_TAG/dblp./}
 
         # We push to Default if the registry host is set
-        if [[ ${DOCKER_REGISTRY}:-""} != "" ]]; then
+        if [ ${DOCKER_REGISTRY:-""} != "" ]; then
             echo "Push image to Default registry (${DOCKER_REGISTRY})"
             pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${docker_repo} ${image_version}
         else

--- a/artifact/artifact_go.sh
+++ b/artifact/artifact_go.sh
@@ -15,6 +15,32 @@ pushDocker() {
     docker logout $1
 }
 
+triggerSecurityScan() {
+    # $1 = docker image name
+    # $2 = docker image tag
+    echo "Trigger security scan on image $1:$2"
+    # Trigger scan at Operations registry
+    curl -X POST \
+        -F token=${OPS_SCAN_TOKEN} \
+        -F ref=master \
+        -F "variables[IMAGE_NAME]=$1" \
+        -F "variables[IMAGE_TAG]=$2" \
+        -F "variables[COMMIT_ID]=${TRAVIS_COMMIT}" \
+        -F "variables[REPO_SLUG]=${TRAVIS_REPO_SLUG}" \
+        https://git.coreye.fr/api/v4/projects/1433/trigger/pipeline
+    # Attach new status "pending" to the commit for aquascanner context
+    # Our Ops partner will update the status once the scanner is finished
+    echo "Set 'pending' status to commit ${TRAVIS_COMMIT}"
+    curl --location --request POST "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_COMMIT}" \
+        --header "Authorization: Bearer ${GITHUB_TOKEN}" \
+        --header 'Content-Type: application/json' \
+        --data-raw '{
+            "state": "pending",
+            "description": "The security scan is running!",
+            "context": "aquascanner"
+        }'
+}
+
 main() {
     if [ "${TRAVIS_GO_VERSION}" != "${ARTIFACT_GO_VERSION}" ]; then
         exit 0
@@ -56,11 +82,18 @@ main() {
     echo "Build Docker image ${docker_repo}"
     docker build --tag "${docker_repo}" .
 
-    # Security scan on the built image
+    # Security scan on the Operations registry
+    # The image has to be pushed to Operations registry to benefit from their security scanner
     if [ ${SECURITY_SCAN:-true} = true ]; then
-        echo "Security scan using Trivy container"
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy image --exit-code 0 --severity MEDIUM,LOW,UNKNOWN ${docker_repo}
-        docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v ${HOME}/.cache:${HOME}/.cache/ --env GITHUB_TOKEN=${GITHUB_TOKEN} aquasec/trivy image --exit-code 1 --severity CRITICAL,HIGH ${docker_repo}
+        echo "Security scan"
+        if [[ ${OPS_DOCKER_REGISTRY:-""} != "" ]]; then
+            echo "Push image to Operations registry (${OPS_DOCKER_REGISTRY})"
+            pushDocker ${OPS_DOCKER_REGISTRY} ${OPS_DOCKER_USERNAME} ${OPS_DOCKER_PASSWORD} ${docker_repo} "scanOnly"
+            triggerSecurityScan ${docker_repo} "scanOnly"
+        else
+            echo "OPS Docker Registry unknown. Security Scan cannot occur."
+            exit 1
+        fi
     fi
 
     # Push docker image only when we have a tag

--- a/artifact/artifact_node.sh
+++ b/artifact/artifact_node.sh
@@ -29,6 +29,7 @@ triggerSecurityScan() {
         -F "variables[REPO_SLUG]=${TRAVIS_REPO_SLUG}" \
         https://git.coreye.fr/api/v4/projects/1433/trigger/pipeline
     # Attach new status "pending" to the commit for aquascanner context
+    # Our Ops partner will update the status once the scanner is finished
     echo "Set 'pending' status to commit ${TRAVIS_COMMIT}"
     curl --location --request POST "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_COMMIT}" \
         --header "Authorization: Bearer ${GITHUB_TOKEN}" \

--- a/artifact/artifact_packaging.sh
+++ b/artifact/artifact_packaging.sh
@@ -10,6 +10,7 @@ echo "TRAVIS_PULL_REQUEST: ${TRAVIS_PULL_REQUEST:-false}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG:-}"
 echo "TRAVIS_REPO_SLUG: ${TRAVIS_REPO_SLUG:-mdblp}"
 echo "NO_DEFAULT_PACKAGING: ${NO_DEFAULT_PACKAGING:-false}"
+echo "TRAVIS_PULL_REQUEST_SHA: ${TRAVIS_PULL_REQUEST_SHA}"
 
 REPO_SLUG="${TRAVIS_REPO_SLUG:-mdblp}"
 APP="${REPO_SLUG#*/}"
@@ -127,17 +128,21 @@ function buildDockerImage {
     docker build --tag "${DOCKER_REPO}" --build-arg npm_token="${NEXUS_TOKEN}" -f "${DOCKER_FILE}" "${DOCKER_TARGET_DIR}"
 
     # Security scan on the Operations registry
+    # The security scan is executed only for a PR build
     # The image has to be pushed to Operations registry to benefit from their security scanner
-    if [ ${SECURITY_SCAN:-true} = true ]; then
+    if [ ${SECURITY_SCAN:-true} = true ] && [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
         echo "Security scan"
-        if [[ ${OPS_DOCKER_REGISTRY:-""} != "" ]]; then
+        local scanTag="${TRAVIS_PULL_REQUEST_SHA}-scanOnly"
+        if [ ${OPS_DOCKER_REGISTRY:-""} != "" ]; then
             echo "Push image to Operations registry (${OPS_DOCKER_REGISTRY})"
-            pushDocker ${OPS_DOCKER_REGISTRY} ${OPS_DOCKER_USERNAME} ${OPS_DOCKER_PASSWORD} ${DOCKER_REPO} "scanOnly"
-            triggerSecurityScan ${DOCKER_REPO} "scanOnly"
+            pushDocker ${OPS_DOCKER_REGISTRY} ${OPS_DOCKER_USERNAME} ${OPS_DOCKER_PASSWORD} ${DOCKER_REPO} ${scanTag}
+            triggerSecurityScan ${DOCKER_REPO} ${scanTag}
         else
             echo "OPS Docker Registry unknown. Security Scan cannot occur."
             exit 1
         fi
+    else
+        echo "Skipping Security Scan"
     fi
 }
 
@@ -166,13 +171,14 @@ triggerSecurityScan() {
         -F ref=master \
         -F "variables[IMAGE_NAME]=$1" \
         -F "variables[IMAGE_TAG]=$2" \
-        -F "variables[COMMIT_ID]=${TRAVIS_COMMIT}" \
+        -F "variables[COMMIT_ID]=${TRAVIS_PULL_REQUEST_SHA}" \
         -F "variables[REPO_SLUG]=${TRAVIS_REPO_SLUG}" \
-        https://git.coreye.fr/api/v4/projects/1433/trigger/pipeline
+        -F "variables[REMOVE_IMAGE]=true" \
+        https://git.coreye.fr/api/v4/projects/1433/trigger/pipeline
     # Attach new status "pending" to the commit for aquascanner context
     # Our Ops partner will update the status once the scanner is finished
-    echo "Set 'pending' status to commit ${TRAVIS_COMMIT}"
-    curl --location --request POST "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_COMMIT}" \
+    echo "Set 'pending' status to commit ${TRAVIS_PULL_REQUEST_SHA}"
+    curl --location --request POST "https://api.github.com/repos/${TRAVIS_REPO_SLUG}/statuses/${TRAVIS_PULL_REQUEST_SHA}" \
         --header "Authorization: Bearer ${GITHUB_TOKEN}" \
         --header 'Content-Type: application/json' \
         --data-raw '{
@@ -191,7 +197,7 @@ function publishDockerImage {
         local image_version=${TRAVIS_TAG/dblp./}
 
         # We push to Default if the registry host is set
-        if [[ ${DOCKER_REGISTRY}:-""} != "" ]]; then
+        if [ ${DOCKER_REGISTRY:-""} != "" ]; then
             echo "Push image to Default registry (${DOCKER_REGISTRY})"
             pushDocker ${DOCKER_REGISTRY} ${DOCKER_USERNAME} ${DOCKER_PASSWORD} ${DOCKER_REPO} ${image_version}
         else


### PR DESCRIPTION
For scanning and take advantage of our Operations partner's scanner, strategy is to send our built image to their registry and trigger a scan to run on their side. Once we sent the image and triggered the scan (only for PR builds), we update the adhoc commit status in Github to "pending" to ensure the branch cannot be merged until the status goes to "success". The status will go "success" once the scan is successful on their side. "Failure" is a possibility.

As the cherry on the cake, it is possible to click on "details" of the scan to get the report behind the status, whether failed or succeeded. We are currently working on getting the HTML version of the scan.

![image](https://user-images.githubusercontent.com/33152621/94583033-46631c00-027d-11eb-8846-0eda36b2c6c8.png)

![image](https://user-images.githubusercontent.com/33152621/94583106-5aa71900-027d-11eb-9d57-907c862521ed.png)

**Once the PR is approved and merged, all the pipelines that go through Travis will use this new security scan mechanism, as the process is adopted by default since previous versions. To not adopt it, the service needs to specify "SECURITY_SCAN=false" in.travis.yml**